### PR TITLE
Switch to safer `yaml.safe_load` instead of `yaml.load`

### DIFF
--- a/bannou/settings.py
+++ b/bannou/settings.py
@@ -148,7 +148,7 @@ class BotSettings:
 
     def __init__(self, path: str) -> None:
         raw_config = pathlib.Path(path).expanduser().read_text()
-        config = yaml.load(raw_config, Loader=YamlLoader)
+        config = yaml.safe_load(raw_config, Loader=YamlLoader)
 
         self._store_config_value("bot_token", config, cast=Secret)
         self._store_config_value("logging", config, default="INFO")


### PR DESCRIPTION
Found out that this is a thing. Using non safe load can lead to code injections. Mostly just for good practise, but better safe than sorry